### PR TITLE
Separate quest update into dedicated (and exposed) method

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Additionally, condition checks can be paused when necessary (e.g. when the game 
 ```gdscript
 Questify.toggle_quest_check(false)
 ```
+In this case, you'll have to manually tell Questify to update the queries using the `Questify.update_quests()` method
 
 ### Serialization and deserialization
 For most cases, Questify can holistically serialize and deserialize state of current quests using methods provided to the autoload:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Additionally, condition checks can be paused when necessary (e.g. when the game 
 ```gdscript
 Questify.toggle_quest_check(false)
 ```
-In this case, you'll have to manually tell Questify to update the queries using the `Questify.update_quests()` method
+If you want to manually trigger quest updates when the timer is disabled, you can use `Questify.update_quests()`.
 
 ### Serialization and deserialization
 For most cases, Questify can holistically serialize and deserialize state of current quests using methods provided to the autoload:

--- a/addons/questify/quest_manager.gd
+++ b/addons/questify/quest_manager.gd
@@ -20,17 +20,16 @@ var _quest_update_timer: Timer
 
 func _ready() -> void:
 	_add_timer()
-	_quest_update_timer.timeout.connect(
-		func():
-			for quest in _quests:
-				quest.update()
-	)
+	_quest_update_timer.timeout.connect(update_quests)
 	
 	
 func start_quest(quest_resource: QuestResource) -> void:
 	_quests.append(quest_resource)
 	quest_resource.start()
 	
+func update_quests():
+	for quest in _quests:
+		quest.update()
 
 func clear() -> void:
 	_quests.clear()


### PR DESCRIPTION
This way, you could disable the quest update timer and instead make the game's DataManager (or equivalent) call update_quests when data has been changed (instead of waiting for the timer to elapse)