### PR TITLE
active quests are now active again after serialize/deserialize

### DIFF
--- a/addons/questify/scripts/model/quest_start.gd
+++ b/addons/questify/scripts/model/quest_start.gd
@@ -14,3 +14,17 @@ func get_active() -> bool:
 	
 func get_completed() -> bool:
 	return active
+
+
+func serialize() -> Dictionary:
+	return {
+		id = id,
+		completed = get_completed(),
+		active = active
+	}
+	
+	
+func deserialize(data: Dictionary) -> void:
+	id = data.id
+	completed = data.completed
+	active = data.active

--- a/addons/questify/scripts/model/quest_start.gd
+++ b/addons/questify/scripts/model/quest_start.gd
@@ -17,14 +17,11 @@ func get_completed() -> bool:
 
 
 func serialize() -> Dictionary:
-	return {
-		id = id,
-		completed = get_completed(),
-		active = active
-	}
+	var data = super()
+	data.active = active
+	return data
 	
 	
 func deserialize(data: Dictionary) -> void:
-	id = data.id
-	completed = data.completed
+	super(data)
 	active = data.active


### PR DESCRIPTION
I have noticed that an active quest is no longer active after deserializing. The active state was not taken into account during serialization and was therefore saved incompletely. 